### PR TITLE
Added Colors Protection checks which run at plugin start

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 # Colors Plugin yml
 name: Colors
-main: com.severalcircles.colors.Main
+main: com.severalcircles.colors.system.Main
 version: Red02
 authors: ["Several Circles", "Minotaur", "Beeg Mo"]
 

--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: com.severalcircles.colors.system.Main
+

--- a/src/com/severalcircles/colors/commands/CommandNedry.java
+++ b/src/com/severalcircles/colors/commands/CommandNedry.java
@@ -24,7 +24,7 @@ public class CommandNedry implements CommandExecutor {
                 player.sendMessage(ChatColor.YELLOW + "Ah Ah Ah! You didn't say the magic word!");
             }
         }
-        int tnt = 0
+        int tnt = 0;
         while (tnt < 3) {
             target.getWorld().spawnEntity(player.getLocation(), EntityType.PRIMED_TNT);
             tnt++;

--- a/src/com/severalcircles/colors/events/ChatEvent.java
+++ b/src/com/severalcircles/colors/events/ChatEvent.java
@@ -1,6 +1,6 @@
 package com.severalcircles.colors.events;
 
-import com.severalcircles.colors.Main;
+import com.severalcircles.colors.system.Main;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/com/severalcircles/colors/system/Main.java
+++ b/src/com/severalcircles/colors/system/Main.java
@@ -1,8 +1,11 @@
-package com.severalcircles.colors;
+package com.severalcircles.colors.system;
 
 import com.severalcircles.colors.commands.CommandAbout;
 import com.severalcircles.colors.commands.CommandNedry;
 import com.severalcircles.colors.commands.CommandPersona;
+import com.severalcircles.colors.system.protection.ProtectionCheck;
+import com.severalcircles.colors.system.protection.ProtectionCheckFailException;
+import com.severalcircles.colors.system.protection.RunViaSpigot;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -11,8 +14,26 @@ import java.net.URL;
 
 public class Main extends JavaPlugin {
     public static int random;
+
+    public static void main(String[] args) {
+        try {
+            throw new ProtectionCheckFailException(new RunViaSpigot());
+        } catch (ProtectionCheckFailException e) {
+            System.out.println("System protection check failed. Exiting.");
+            System.exit(69);
+        }
+    }
+
     @Override
     public void onEnable() {
+        try {
+            ProtectionCheck.runChecks();
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        } catch (ProtectionCheckFailException e) {
+            System.out.println("System protection check failed. Disabling.");
+            getServer().getPluginManager().disablePlugin(this);
+        }
         try {
             System.out.println("Build number: " + classBuildTimeMillis());
         } catch (URISyntaxException e) {

--- a/src/com/severalcircles/colors/system/protection/BuildExpiry.java
+++ b/src/com/severalcircles/colors/system/protection/BuildExpiry.java
@@ -1,0 +1,45 @@
+package com.severalcircles.colors.system.protection;
+
+//import java.sql.Time;
+//
+//import static org.graalvm.compiler.debug.DebugOptions.Time;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Date;
+
+public class BuildExpiry extends ProtectionCheck {
+    private final Date date = new Date();
+    private final long time = date.getTime();
+    private final long month = 2592 * 1000000; // Because java is really dumb about defining longs
+
+    @Override
+    boolean checkPass() throws URISyntaxException {
+        return classBuildTimeMillis() - time < month;
+    }
+
+    private long classBuildTimeMillis() throws URISyntaxException, IllegalStateException, IllegalArgumentException {
+        URL resource = getClass().getResource(getClass().getSimpleName() + ".class");
+        if (resource == null) {
+            throw new IllegalStateException("Failed to find class file for class: " +
+                    getClass().getName());
+        }
+
+        if (resource.getProtocol().equals("file")) {
+
+            return new File(resource.toURI()).lastModified();
+
+        } else if (resource.getProtocol().equals("jar")) {
+
+            String path = resource.getPath();
+            return new File(path.substring(5, path.indexOf("!"))).lastModified();
+
+        } else {
+
+            throw new IllegalArgumentException("Unhandled url protocol: " +
+                    resource.getProtocol() + " for class: " +
+                    getClass().getName() + " resource: " + resource.toString());
+        }
+    }
+}

--- a/src/com/severalcircles/colors/system/protection/ProtectionCheck.java
+++ b/src/com/severalcircles/colors/system/protection/ProtectionCheck.java
@@ -1,0 +1,13 @@
+package com.severalcircles.colors.system.protection;
+
+import java.net.URISyntaxException;
+
+public abstract class ProtectionCheck {
+    public static void runChecks() throws URISyntaxException, ProtectionCheckFailException {
+        if (!new BuildExpiry().checkPass()) {
+            throw new ProtectionCheckFailException(new BuildExpiry());
+        }
+    }
+
+    abstract boolean checkPass() throws URISyntaxException;
+}

--- a/src/com/severalcircles/colors/system/protection/ProtectionCheckFailException.java
+++ b/src/com/severalcircles/colors/system/protection/ProtectionCheckFailException.java
@@ -1,0 +1,13 @@
+package com.severalcircles.colors.system.protection;
+
+import org.bukkit.ChatColor;
+
+public class ProtectionCheckFailException extends Exception {
+    public ProtectionCheckFailException(ProtectionCheck failedCheck) {
+        if (failedCheck == new RunViaSpigot()) {
+            System.out.println("The RunViaSpigot Colors System Protection check has failed.\nNever run Colors via the JAR always run it via Spigot.");
+        }
+        System.out.println(ChatColor.RED + "A Colors System protection check has failed\nFailed check: " + failedCheck.toString() + "\nPlease download the latest version of Colors from the official GitHub and avoid using out-of date\nor unofficial versions to prevent damage to the plugin or your server.");
+    }
+
+}

--- a/src/com/severalcircles/colors/system/protection/RunViaSpigot.java
+++ b/src/com/severalcircles/colors/system/protection/RunViaSpigot.java
@@ -1,0 +1,10 @@
+package com.severalcircles.colors.system.protection;
+
+import java.net.URISyntaxException;
+
+public class RunViaSpigot extends ProtectionCheck {
+    @Override
+    boolean checkPass() throws URISyntaxException {
+        return true;
+    }
+}


### PR DESCRIPTION
Added protection features to prevent plugin from being run in environments and in ways not intended. If any protection checks fail, the plugin will not load. Checks implemented with this pull request include:

- BuildExpiry - Prevents plugin from being run more than 30 days after build date, thereby requiring the user to update the plugin from an official source.
- RunViaSpigot - Prevents plugin from being run by the JAR it comes in, instead requiring the user to run it through a Spigot or Bukkit server

The framework is currently open for more checks to be implemented.